### PR TITLE
Make copy-stream work for CMUCL Gray Streams

### DIFF
--- a/fad.lisp
+++ b/fad.lisp
@@ -233,9 +233,8 @@ checked for compatibility of their types."
   (let ((buf (make-array *stream-buffer-size*
                          :element-type (stream-element-type from))))
     (loop
-       (let ((pos #-(or :clisp :cmu) (read-sequence buf from)
-                  #+:clisp (ext:read-byte-sequence buf from :no-hang nil)
-                  #+:cmu (sys:read-n-bytes from buf 0 *stream-buffer-size* nil)))
+       (let ((pos #-:clisp (read-sequence buf from)
+                  #+:clisp (ext:read-byte-sequence buf from :no-hang nil)))
          (when (zerop pos) (return))
          (write-sequence buf to :end pos))))
   (values))


### PR DESCRIPTION
cl-fad's copy-stream fails on cmucl when the "from" arg is a Gray Stream.
That's because it calls an internal cmucl function, sys:read-n-bytes .
But that function is meant only for non-Gray Streams.
This fixes the problem, by just calling read-sequence instead.