### PR TITLE
fix pathname-parent-directory for filenames

### DIFF
--- a/fad.lisp
+++ b/fad.lisp
@@ -332,7 +332,7 @@ by this function is a directory name which contains PATHNAME.
 The root directory, #P\"/\", is its own parent. The parent directory
 of a filename is the parent of the filename's dirname."
   (canonical-pathname
-   (make-pathname :defaults pathname
+   (make-pathname
                   :directory (if (pathname-root-p pathname)
                                  (list :absolute)
                                  (append (or (pathname-directory pathname)

--- a/fad.lisp
+++ b/fad.lisp
@@ -332,7 +332,9 @@ by this function is a directory name which contains PATHNAME.
 The root directory, #P\"/\", is its own parent. The parent directory
 of a filename is the parent of the filename's dirname."
   (canonical-pathname
-   (make-pathname
+   (make-pathname :defaults pathname
+                  :name nil
+                  :type nil
                   :directory (if (pathname-root-p pathname)
                                  (list :absolute)
                                  (append (or (pathname-directory pathname)


### PR DESCRIPTION
Before:
```
[5]> (pathname-parent-directory #P"/a/b/c")
# P"/a/c"
```
which is meaningless and disagrees with the function's docstring.
After:
```
[7]> (pathname-parent-directory #P"/a/b/c")
# P"/a/"
```
which agrees with the function's docstring, "The parent directory of a filename is the parent of the filename's dirname."