### PR TITLE
Removing dependence to bordeaux-threads for LispWorks.

### DIFF
--- a/cl-fad.asd
+++ b/cl-fad.asd
@@ -39,7 +39,7 @@
                (:file "fad")
                (:file "path" :depends-on ("fad"))
                (:file "temporary-files" :depends-on ("fad")))
-  :depends-on (#+sbcl :sb-posix :bordeaux-threads :alexandria))
+  :depends-on (#+sbcl :sb-posix #-lispworks :bordeaux-threads :alexandria))
 
 (asdf:defsystem #:cl-fad-test
   :serial t

--- a/temporary-files.lisp
+++ b/temporary-files.lisp
@@ -71,10 +71,20 @@
 
 ;; locking for multi-threaded operation with unsafe random function
 
+#-lispworks
 (defvar *create-file-name-lock* (bordeaux-threads:make-lock "Temporary File Name Creation Lock"))
 
+#-lispworks
 (defmacro with-file-name-lock-held (() &body body)
   `(bordeaux-threads:with-lock-held (*create-file-name-lock*)
+     ,@body))
+
+#+lispworks
+(defvar *create-file-name-lock* (mp:make-lock :name "Temporary File Name Creation Lock"))
+
+#+lispworks
+(defmacro with-file-name-lock-held (() &body body)
+  `(mp:with-lock (*create-file-name-lock*)
      ,@body))
 
 (defun generate-random-string ()


### PR DESCRIPTION
Replacing bordeaux-threads with built-in LispWorks functionality to keep dependencies down to a minimum for LispWorks users.