### PR TITLE
Export GET-DEFAULT-TEMPORARY-DIRECTORY

### DIFF
--- a/packages.lisp
+++ b/packages.lisp
@@ -65,6 +65,7 @@
            :*default-template*
            :invalid-temporary-pathname-template
            :cannot-create-temporary-file
+           :get-default-temporary-directory
            #+win32 #:missing-temp-environment-variable))
 
 (defpackage :path


### PR DESCRIPTION
I want to run unit tests which create directory and file structures on hard drive. Because of this, I would like to make a temporary directory instead of a temporary file.

I see that CL-FAD already has a function for returning such a directory, but its symbol is not external.