### PR TITLE
fix CLISP function for directory deletion

### DIFF
--- a/fad.lisp
+++ b/fad.lisp
@@ -305,7 +305,7 @@ might be removed instead!  This is currently fixed for SBCL and CCL."
                                     (unless ok
                                       (error "~@<Error deleting ~S: ~A~@:>"
                                              file (unix:get-unix-error-msg errno))))
-                           #+:clisp (ext:delete-dir file)
+                           #+:clisp (ext:delete-directory file)
                            #+:openmcl (cl-fad-ccl:delete-directory file)
                            #+:cormanlisp (win32:delete-directory file)
                            #+:ecl (si:rmdir file)


### PR DESCRIPTION
symbol is incorrect
`*** - READ from #<INPUT BUFFERED FILE-STREAM CHARACTER #P"/home/c4b3z0n/quicklisp/dists/quicklisp/software/cl-fad-20180430-git/fad.lisp" @308>: #<PACKAGE EXT> has no external symbol with name "DELETE-DIR"`

should be ext:delete-directory