### PR TITLE
Fix initialisation of TEMPORARY-FILES logical pathname

### DIFF
--- a/temporary-files.lisp
+++ b/temporary-files.lisp
@@ -42,19 +42,19 @@
       (when (plusp (length string))
         (pathname-as-directory string))))
 
-  #+win32
+  #+(or mswindows win32)
   (define-condition missing-temp-environment-variable (error)
     ()
     (:report (lambda (condition stream)
                (declare (ignore condition))
                (format stream "the TEMP environment variable has not been found, cannot continue"))))
 
-  #+win32
+  #+(or mswindows win32)
   (defun get-default-temporary-directory ()
     (or (directory-from-environment "TEMP")
         (error 'missing-temp-environment-variable)))
 
-  #-win32
+  #-(or mswindows win32)
   (defun get-default-temporary-directory ()
     (or (directory-from-environment "TMPDIR")
         (and #-clisp (probe-file #P"/tmp/")


### PR DESCRIPTION
ACL defines the feature `MSWINDOWS` instead of `WIN32`.