### PR TITLE
Add tests for coverage, fix one bug found

### DIFF
--- a/fad.lisp
+++ b/fad.lisp
@@ -229,7 +229,7 @@ of FROM is reached, in blocks of *stream-buffer-size*.  The streams
 should have the same element type.  If CHECKP is true, the streams are
 checked for compatibility of their types."
   (when checkp
-    (unless (subtypep (stream-element-type to) (stream-element-type from))
+    (unless (subtypep (stream-element-type from) (stream-element-type to))
       (error "Incompatible streams ~A and ~A." from to)))
   (let ((buf (make-array *stream-buffer-size*
                          :element-type (stream-element-type from))))

--- a/packages.test.lisp
+++ b/packages.test.lisp
@@ -2,4 +2,5 @@
 
 (defpackage :cl-fad-test
   (:use :cl :cl-fad :unit-test)
+  (:shadowing-import-from :cl-fad :pathname-directory-equal)
   (:export :test))


### PR DESCRIPTION
Copy stream had a wrongly oriented test for stream element type
containment.